### PR TITLE
Fix PNG upload processing

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -4,10 +4,20 @@ import io
 
 st.title("PNG → PDF 変換ツール（Web）")
 
-uploaded_files = st.file_uploader("PNGファイルをアップロード（複数可）", type="png", accept_multiple_files=True)
+uploaded_files = st.file_uploader(
+    "PNGファイルをアップロード（複数可）",
+    type=["png", "PNG"],
+    accept_multiple_files=True,
+)
 
 if uploaded_files:
-    images = [Image.open(file).convert("RGB") for file in uploaded_files]
-    buf = io.BytesIO()
-    images[0].save(buf, format="PDF", save_all=True, append_images=images[1:])
-    st.download_button("📄 PDFをダウンロード", buf.getvalue(), file_name="converted.pdf")
+    images = []
+    for file in uploaded_files:
+        with Image.open(file) as img:
+            images.append(img.convert("RGB"))
+
+    with io.BytesIO() as buf:
+        images[0].save(buf, format="PDF", save_all=True, append_images=images[1:])
+        pdf_bytes = buf.getvalue()
+
+    st.download_button("📄 PDFをダウンロード", pdf_bytes, file_name="converted.pdf")


### PR DESCRIPTION
## Summary
- close uploaded image files and handle case-insensitive extensions
- use a temporary buffer with context manager

## Testing
- `python -m py_compile streamlit.py`

------
https://chatgpt.com/codex/tasks/task_e_683fcfc59644832c946c371186d7a5ad