### PR TITLE
Add PDF conversion tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+      - name: Install Python dependencies
+        run: pip install Pillow pdf2image pytest
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+tests/__pycache__/

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,0 +1,18 @@
+import io
+from typing import List
+from PIL import Image
+
+
+def images_to_pdf(images: List[Image.Image]) -> bytes:
+    """Convert a list of PIL Images to PDF bytes."""
+    if not images:
+        raise ValueError("No images provided")
+    rgb_images = [img.convert("RGB") for img in images]
+    with io.BytesIO() as buf:
+        rgb_images[0].save(
+            buf,
+            format="PDF",
+            save_all=True,
+            append_images=rgb_images[1:],
+        )
+        return buf.getvalue()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv

--- a/streamlit.py
+++ b/streamlit.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from PIL import Image
 import io
+from pdf_utils import images_to_pdf
 
 st.title("PNG → PDF 変換ツール（Web）")
 
@@ -16,8 +17,6 @@ if uploaded_files:
         with Image.open(file) as img:
             images.append(img.convert("RGB"))
 
-    with io.BytesIO() as buf:
-        images[0].save(buf, format="PDF", save_all=True, append_images=images[1:])
-        pdf_bytes = buf.getvalue()
+    pdf_bytes = images_to_pdf(images)
 
     st.download_button("📄 PDFをダウンロード", pdf_bytes, file_name="converted.pdf")

--- a/tests/test_pdf_conversion.py
+++ b/tests/test_pdf_conversion.py
@@ -1,0 +1,29 @@
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pdf_utils import images_to_pdf
+from PIL import Image
+from pdf2image import convert_from_bytes
+
+
+def create_sample_images(count):
+    images = []
+    for i in range(count):
+        img = Image.new("RGB", (10, 10), color=(i * 20 % 255, i * 30 % 255, i * 40 % 255))
+        images.append(img)
+    return images
+
+
+def test_pdf_page_count(tmp_path):
+    imgs = create_sample_images(3)
+    pdf_bytes = images_to_pdf(imgs)
+
+    # write to tmp file
+    pdf_path = tmp_path / "output.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+
+    pages = convert_from_bytes(pdf_bytes)
+    assert len(pages) == 3


### PR DESCRIPTION
## Summary
- refactor streamlit app to use a new `images_to_pdf` helper
- add `pdf_utils.py` providing PDF conversion logic
- introduce `tests/test_pdf_conversion.py` with pytest
- add `pytest.ini` for basic pytest options
- add GitHub Actions workflow to run tests on pull requests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_683fd31197f0832cbc83ad8ea8dce960