### PR TITLE
Fix cropping HTML widget

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -83,7 +83,6 @@ def cropper(img: Image.Image, key: str):
         </script>
         """,
         height=400,
-        key=key,
     )
     return component
 


### PR DESCRIPTION
## Summary
- remove unsupported `key` from HTML component call so cropping works on older Streamlit versions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684bafcbfaf4832cbdd5c6241872e440