### PR TITLE
Handle unexpected cropper return type

### DIFF
--- a/streamlit.py
+++ b/streamlit.py
@@ -83,7 +83,6 @@ def cropper(img: Image.Image, key: str):
         </script>
         """,
         height=400,
-        key=key,
     )
     return component
 
@@ -112,7 +111,7 @@ if uploaded_files:
                 )
                 flip = st.checkbox("flip horizontally", key=f"{file.name}_flip")
 
-            if coords:
+            if isinstance(coords, dict):
                 crop_box = (
                     coords.get("left", 0),
                     coords.get("top", 0),


### PR DESCRIPTION
## Summary
- handle non-dict return values from the cropper widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684bafcbfaf4832cbdd5c6241872e440